### PR TITLE
calling mod_php5 recipe, adding deps

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,6 @@ license          'All rights reserved'
 description      'Installs/Configures promet_php'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
+
+depends 'apache2'
+depends 'php'

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -8,6 +8,7 @@
 #
 
 include_recipe "php"
+include_recipe "apache2::mod_php5"
 
 template "/etc/php5/apache2/php.ini" do
  source "php.ini.erb"


### PR DESCRIPTION
This cookbook templates a file that only exists if the apache2 php module is installed, and needs deps added to metadata.rb
